### PR TITLE
Build menus from dicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,24 @@ menu.show_menu()
 
 In the above menu, clicking 'Shut down' would invoke the CPython `reset()` function. Clicking 'Screen brightness' would open a screen for adjusting the value of `screen.brightness` and, once set, would invoke the function `update_screen_brightness` with the updated value. Note that the specified callback is responsible for "setting" the new value; the adjust menu only provides an interface for users to select a new value but does not itself update the named variable. Finally, the call to `show_menu()` tells the Fruity Menu to render itself to the screen.
 
+**Using a dict to create a menu**
+You can also use a `dict` to create a menu. This can be give more readable code. The same menu as above could be created as:
+
+```py
+menu_items = {
+    'Shut down': microcontroller.reset,
+    'Settings': {
+        'Screen brightness': Value(screen.brightness, update_screen_brightness)
+    }
+}
+menu = Menu(display, title='Main Menu')
+build_menu(menu, menu_items)
+
+menu.show_menu()
+```
+Note using `Value` to provide the other arguments that would be used in `add_value_button`
+
+
 ## Supplying inputs
 Fruity Menus are navigated using `Menu.scroll(delta)` and `Menu.click()`. When scrolling, `delta` is the number of menu items to advance; a negative `delta` scrolls the other way.
 

--- a/fruity_menu/adjust.py
+++ b/fruity_menu/adjust.py
@@ -144,7 +144,7 @@ class NumberMenu(AdjustMenu):
             self.property = post_scroll_value
 
 
-class ArrayMenu(AdjustMenu):
+class OptionMenu(AdjustMenu):
     """Menu for adjusting the value of a numeric variable"""
 
     options: List

--- a/fruity_menu/builder.py
+++ b/fruity_menu/builder.py
@@ -1,0 +1,32 @@
+try:
+    from typing import Union, TypeAlias, Callable
+    TreeElement: TypeAlias = dict[str, Union["TreeElement",Callable, "Value"]]
+except ImportError:
+    TreeElement = dict
+from fruity_menu.menu import Menu
+
+
+class Value:
+    """
+    This is a holder to keep the arguments to create a ValueButton
+    """
+    def __init__(self, value, on_value_set = None, on_set_args = None,
+                         scroll_factor = 1, min_val = None, max_val = None):
+        self.value = value
+        self.on_value_set = on_value_set
+        self.on_set_args = on_set_args
+        self.scroll_factor = scroll_factor
+        self.min_val = min_val
+        self.max_val = max_val
+
+
+def build_menu(menu: Menu, structure: TreeElement):
+    for k, v in structure.items():
+        if isinstance(v, dict):
+            submenu = menu.create_menu(k)
+            build_menu(submenu,v)
+            menu.add_submenu_button(k, submenu)
+        elif isinstance(v, Value):
+            menu.add_value_button(k, **v.__dict__)
+        elif callable(v):
+            menu.add_action_button(k, v)

--- a/fruity_menu/builder.py
+++ b/fruity_menu/builder.py
@@ -36,6 +36,15 @@ class Options:
         self.on_set_args = on_set_args
 
 
+class Action:
+    """
+    This is a holder to keep the arguments to create an ActionMenu
+    """
+    def __init__(self, function, *args):
+        self.function = function
+        self.args = args
+
+
 def build_menu(menu: Menu, structure: TreeElement):
     if isinstance(structure, (list, tuple)):
         structure = OrderedDict(structure)
@@ -48,5 +57,7 @@ def build_menu(menu: Menu, structure: TreeElement):
             menu.add_value_button(k, **v.__dict__)
         elif isinstance(v, Options):
             menu.add_option_button(k, **v.__dict__)
+        elif isinstance(v, Action):
+            menu.add_action_button(k, v.function, v.args)
         elif callable(v):
             menu.add_action_button(k, v)

--- a/fruity_menu/builder.py
+++ b/fruity_menu/builder.py
@@ -1,6 +1,10 @@
+from collections import OrderedDict
+
 try:
     from typing import Union, TypeAlias, Callable
-    TreeElement: TypeAlias = dict[str, Union["TreeElement",Callable, "Value"]]
+    TreeDictElement: TypeAlias = dict[str, Union["TreeElement",Callable, "Value"]]
+    TreeListElement: TypeAlias = list[Tuple[str, Union["TreeElement",Callable, "Value"]]]
+    TreeElement = Union[TreeDictElement, TreeListElement]
 except ImportError:
     TreeElement = dict
 from fruity_menu.menu import Menu
@@ -18,15 +22,31 @@ class Value:
         self.scroll_factor = scroll_factor
         self.min_val = min_val
         self.max_val = max_val
+        
+        
+class Options:
+    """
+    This is a holder to keep the arguments to create an OptionMenu
+    """
+    def __init__(self, value, options, *, option_labels = None, on_value_set=None, on_set_args=None):
+        self.value = value
+        self.options = options
+        self.option_labels = option_labels
+        self.on_value_set = on_value_set
+        self.on_set_args = on_set_args
 
 
 def build_menu(menu: Menu, structure: TreeElement):
+    if isinstance(structure, (list, tuple)):
+        structure = OrderedDict(structure)
     for k, v in structure.items():
-        if isinstance(v, dict):
+        if isinstance(v, (dict, list)):
             submenu = menu.create_menu(k)
             build_menu(submenu,v)
             menu.add_submenu_button(k, submenu)
         elif isinstance(v, Value):
             menu.add_value_button(k, **v.__dict__)
+        elif isinstance(v, Options):
+            menu.add_option_button(k, **v.__dict__)
         elif callable(v):
             menu.add_action_button(k, v)

--- a/fruity_menu/builder.py
+++ b/fruity_menu/builder.py
@@ -30,8 +30,14 @@ class Options:
     """
     def __init__(self, value, options, *, option_labels = None, on_value_set=None, on_set_args=None):
         self.value = value
-        self.options = options
-        self.option_labels = option_labels
+        try:
+            dct = OrderedDict(options)
+        except ValueError:
+            self.options = options
+            self.option_labels = option_labels
+        else:
+            self.options = list(dct.values())
+            self.option_labels = list(dct.keys())
         self.on_value_set = on_value_set
         self.on_set_args = on_set_args
 

--- a/fruity_menu/menu.py
+++ b/fruity_menu/menu.py
@@ -1,4 +1,9 @@
 from math import ceil, floor
+try:
+    from typing import List, Optional
+except ImportError:
+    pass
+
 from displayio import Display, Group
 from os import getcwd
 import terminalio
@@ -6,7 +11,7 @@ from time import time
 from adafruit_display_text.label import Label
 from adafruit_bitmapsaver import save_pixels
 
-from fruity_menu.adjust import AdjustMenu, BoolMenu, NumberMenu
+from fruity_menu.adjust import AdjustMenu, BoolMenu, NumberMenu, ArrayMenu
 from fruity_menu.abstract import AbstractMenu
 from fruity_menu.options import ActionButton, SubmenuButton, ValueButton
 
@@ -150,6 +155,17 @@ class Menu(AbstractMenu):
         else:
             raise NotImplementedError()
             
+        val = ValueButton(title, value, submenu, self._submenu_is_opening)
+        val.upmenu = self
+        self._options.append(val)
+        return val
+
+    def add_option_button(self, title: str, value, options: List,
+                 option_labels: Optional[List]=None, on_value_set=None, on_set_args=None):
+        submenu = ArrayMenu(value, options, title, self._height, self._width,
+                            option_labels=option_labels,
+                            value_set=on_value_set,
+                            value_set_args=on_set_args)
         val = ValueButton(title, value, submenu, self._submenu_is_opening)
         val.upmenu = self
         self._options.append(val)

--- a/fruity_menu/menu.py
+++ b/fruity_menu/menu.py
@@ -205,7 +205,7 @@ class Menu(AbstractMenu):
             else:
                 lbl.color = OPT_TEXT_COLOR
                 lbl.background_color = OPT_BACK_COLOR
-            lbl.anchor_point = (0,0)
+            lbl.anchor_point = (0, 0)
             lbl.anchored_position = (self._x, self._y)
             grp.append(lbl)
 
@@ -236,10 +236,9 @@ class Menu(AbstractMenu):
         will also display the `Group` itself.
         """
         # if no submenu is open, then show this menu
-        print('showing', self._title)
         if self._activated_submenu is None:
             grp = self.build_displayio_group()
-            self._display.show(grp)
+            self._display.root_group = grp
             self._is_active = True
             return grp
         else:
@@ -247,7 +246,7 @@ class Menu(AbstractMenu):
             # main and submenus can show themselves, but adjustmenus have to *be* shown
             if (isinstance(self._activated_submenu, AdjustMenu)):
                 grp = self._activated_submenu.build_displayio_group()
-                self._display.show(grp)
+                self._display.root_group = grp
                 return grp
             else:
                 return self._activated_submenu.show_menu()

--- a/fruity_menu/menu.py
+++ b/fruity_menu/menu.py
@@ -11,7 +11,7 @@ from time import time
 from adafruit_display_text.label import Label
 from adafruit_bitmapsaver import save_pixels
 
-from fruity_menu.adjust import AdjustMenu, BoolMenu, NumberMenu, ArrayMenu
+from fruity_menu.adjust import AdjustMenu, BoolMenu, NumberMenu, OptionMenu
 from fruity_menu.abstract import AbstractMenu
 from fruity_menu.options import ActionButton, SubmenuButton, ValueButton
 
@@ -162,7 +162,7 @@ class Menu(AbstractMenu):
 
     def add_option_button(self, title: str, value, options: List,
                  option_labels: Optional[List]=None, on_value_set=None, on_set_args=None):
-        submenu = ArrayMenu(value, options, title, self._height, self._width,
+        submenu = OptionMenu(value, options, title, self._height, self._width,
                             option_labels=option_labels,
                             value_set=on_value_set,
                             value_set_args=on_set_args)

--- a/fruity_menu/menu.py
+++ b/fruity_menu/menu.py
@@ -8,7 +8,7 @@ from displayio import Display, Group
 from os import getcwd
 import terminalio
 from time import time
-from adafruit_display_text.label import Label
+from adafruit_display_text.bitmap_label import Label
 from adafruit_bitmapsaver import save_pixels
 
 from fruity_menu.adjust import AdjustMenu, BoolMenu, NumberMenu, OptionMenu
@@ -197,8 +197,7 @@ class Menu(AbstractMenu):
             if (i + index_offset >= len(self._options)):
                 continue
             opt = self._options[i + index_offset]
-            lbl = Label(terminalio.FONT)
-            lbl.text = opt.text
+            lbl = Label(terminalio.FONT, text=opt.text, save_text=False)
 
             if i == selected_relative_row:
                 lbl.color = OPT_HIGHLIGHT_TEXT_COLOR
@@ -217,8 +216,7 @@ class Menu(AbstractMenu):
 
     def get_title_label(self) -> Label:
         """Gets the Label for this menu's title and adjusts the builder's coordinates to compensate for the object"""
-        lbl = Label(terminalio.FONT)
-        lbl.text = '    ' + self._title
+        lbl = Label(terminalio.FONT, text='    ' + self._title, save_text=False)
         lbl.color = OPT_HIGHLIGHT_TEXT_COLOR
         lbl.background_color = OPT_HIGHLIGHT_BACK_COLOR
         lbl.anchored_position = (0, self._y)

--- a/fruity_menu/options.py
+++ b/fruity_menu/options.py
@@ -21,7 +21,7 @@ class ActionButton(AbstractMenuOption):
         if self._args is None:
             self._action()
         else:
-            self._action(self._args)
+            self._action(*self._args)
         return True
         
 

--- a/fruity_menu/test_builder.py
+++ b/fruity_menu/test_builder.py
@@ -1,0 +1,54 @@
+from unittest import TestCase
+from unittest.mock import patch, Mock
+
+import fruity_menu.menu
+from fruity_menu.builder import build_menu, Value
+
+def dummy_function():
+    pass
+
+@patch("fruity_menu.menu.Menu")
+class TestBuilder(TestCase):
+
+    def testActionAdd(self, Menu):
+        menu: Mock = Menu()
+        dct = {"test": dummy_function}
+        build_menu(menu, dct)
+        menu.add_action_button.assert_called_once_with("test", dummy_function)
+
+    def testValueAddMinimal(self, Menu):
+        i = 0
+        menu: Mock = Menu()
+        dct = {"test": Value(i, dummy_function)}
+        build_menu(menu, dct)
+        menu.add_value_button.assert_called_once_with("test",
+                                                      value=i,
+                                                      on_value_set= dummy_function,
+                                                      on_set_args=None,
+                                                      scroll_factor=1,
+                                                      min_val=None,
+                                                      max_val=None)
+
+    def testValueAddMaximal(self, Menu):
+        i = 0
+        menu: Mock = Menu()
+        dct = {"test": Value(i, on_value_set = dummy_function, on_set_args="set_args",
+                             scroll_factor=2, min_val=-1, max_val=10)}
+        build_menu(menu, dct)
+        menu.add_value_button.assert_called_once_with("test",
+                                                      value=i,
+                                                      on_value_set= dummy_function,
+                                                      on_set_args= "set_args",
+                                                      scroll_factor=2,
+                                                      min_val=-1,
+                                                      max_val=10)
+
+    def testSubMenuAdd(self, Menu):
+        menu: Mock = Menu()
+        sub_menu = Mock()
+        menu.create_menu.return_value = sub_menu
+        dct = {"sub_menu": {"test": dummy_function}}
+        build_menu(menu, dct)
+        menu.create_menu.assert_called_once_with("sub_menu")
+        sub_menu.add_action_button.assert_called_once_with("test", dummy_function)
+        menu.add_submenu_button.assert_called_once_with("sub_menu", sub_menu)

--- a/fruity_menu/test_builder.py
+++ b/fruity_menu/test_builder.py
@@ -52,3 +52,13 @@ class TestBuilder(TestCase):
         menu.create_menu.assert_called_once_with("sub_menu")
         sub_menu.add_action_button.assert_called_once_with("test", dummy_function)
         menu.add_submenu_button.assert_called_once_with("sub_menu", sub_menu)
+
+    def testSubMenuAddWithLists(self, Menu):
+        menu: Mock = Menu()
+        sub_menu = Mock()
+        menu.create_menu.return_value = sub_menu
+        dct = [("sub_menu", [("test", dummy_function)])]
+        build_menu(menu, dct)
+        menu.create_menu.assert_called_once_with("sub_menu")
+        sub_menu.add_action_button.assert_called_once_with("test", dummy_function)
+        menu.add_submenu_button.assert_called_once_with("sub_menu", sub_menu)

--- a/test/test_adjust_array.py
+++ b/test/test_adjust_array.py
@@ -1,0 +1,107 @@
+import unittest
+from unittest.mock import Mock
+from fruity_menu.adjust import ArrayMenu
+
+from test.test_menu import HEIGHT, WIDTH
+
+
+class ArrayMenuTests(unittest.TestCase):
+    title: str = 'The Title'
+    list_options = [10, 20, 30, 60]
+    labels = ['A', 'B', 'C', 'D']
+
+    def test_getDisplayIoGroup(self):
+        value = 10
+        self.a_menu = ArrayMenu(value, self.list_options, self.title, HEIGHT, WIDTH)
+        grp = self.a_menu.build_displayio_group()
+        self.assertEqual(self.title, grp[0].text)
+        self.assertEqual(str(10), grp[1].text)
+        self.assertEqual(2, len(grp), 'Group contains unexpected elements')
+
+    def test_getDisplayIoGroup_with_labels(self):
+        value = 10
+        self.a_menu = ArrayMenu(value, self.list_options, self.title, HEIGHT, WIDTH,
+                                option_labels=self.labels)
+        grp = self.a_menu.build_displayio_group()
+        self.assertEqual(self.title, grp[0].text)
+        self.assertEqual(str(self.labels[0]), grp[1].text)
+        self.assertEqual(2, len(grp), 'Group contains unexpected elements')
+
+    def test_click_invokesStoredAction_withArgs(self):
+        value = 10
+        self.a_menu = ArrayMenu(value, self.list_options, self.title, HEIGHT, WIDTH)
+        self.a_menu.on_value_set = Mock()
+        self.a_menu.on_value_set_args = Mock()
+        click_value = self.a_menu.click()
+        self.a_menu.on_value_set.assert_called_once_with(self.a_menu.on_value_set_args, value)
+        self.assertFalse(click_value)
+
+    def test_click_invokesStoredAction_withoutArgs(self):
+        value = 10
+        self.a_menu = ArrayMenu(value, self.list_options, self.title, HEIGHT, WIDTH)
+        self.a_menu.on_value_set = Mock()
+        self.a_menu.on_value_set_args = None
+        click_value = self.a_menu.click()
+        self.a_menu.on_value_set.assert_called_once_with(value)
+        self.assertFalse(click_value)
+
+    def test_click_justReturnIfNoStoredAction(self):
+        value = 10
+        self.a_menu = ArrayMenu(value, self.list_options, self.title, HEIGHT, WIDTH)
+        self.a_menu.on_value_set = None
+        self.assertFalse(self.a_menu.click())
+
+    def test_scroll_advances_correctly(self):
+        value = 10
+        self.a_menu = ArrayMenu(value, self.list_options, self.title, HEIGHT, WIDTH)
+        self.a_menu.scroll(1)
+        self.assertEqual(20, self.a_menu.property)
+
+    def test_scroll_advances_correctly_with_labels(self):
+        value = 10
+        self.a_menu = ArrayMenu(value, self.list_options, self.title, HEIGHT, WIDTH,
+                                option_labels=self.labels)
+        self.a_menu.scroll(1)
+        self.assertEqual(20, self.a_menu.property)
+
+    def test_scroll_wraps_on_increment(self):
+        value = 60
+        self.a_menu = ArrayMenu(value, self.list_options, self.title, HEIGHT, WIDTH)
+        self.a_menu.scroll(1)
+        self.assertEqual(10, self.a_menu.property)
+
+    def test_scroll_wraps_on_increment_with_labels(self):
+        value = 60
+        self.a_menu = ArrayMenu(value, self.list_options, self.title, HEIGHT, WIDTH,
+                                option_labels=self.labels)
+        self.a_menu.scroll(1)
+        self.assertEqual(10, self.a_menu.property)
+
+    def test_scroll_wraps_on_decrement(self):
+        value = 10
+        self.a_menu = ArrayMenu(value, self.list_options, self.title, HEIGHT, WIDTH)
+        self.a_menu.scroll(-1)
+        self.assertEqual(60, self.a_menu.property)
+
+    def test_scroll_wraps_on_decrement_with_labels(self):
+        value = 10
+        self.a_menu = ArrayMenu(value, self.list_options, self.title, HEIGHT, WIDTH,
+                                option_labels=self.labels)
+        self.a_menu.scroll(-1)
+        self.assertEqual(60, self.a_menu.property)
+
+    def test_raises_error_if_value_not_in_options_list(self):
+        value = 15
+        with self.assertRaises(ValueError):
+            self.a_menu = ArrayMenu(value, self.list_options, self.title, HEIGHT, WIDTH)
+
+    def test_raises_error_if_value_not_in_options_dict(self):
+        value = 15
+        with self.assertRaises(ValueError):
+            self.a_menu = ArrayMenu(value, self.list_options, self.title, HEIGHT, WIDTH,
+                                    option_labels=self.labels)
+
+    def test_raises_error_if_labels_list_different_length_to_options(self):
+        with self.assertRaises(ValueError):
+            self.a_menu = ArrayMenu(10, [10, 20, 30], self.title, HEIGHT, WIDTH,
+                                    option_labels=["a", "b", "c", "d"])


### PR DESCRIPTION
This pull request allows one to create dicts to describe the menu structure - like this:

```py
menu_items = {
    'Shut down': microcontroller.reset,
    'Settings': {
        'Screen brightness': Value(screen.brightness, update_screen_brightness)
    }
}
menu = Menu(display, title='Main Menu')
build_menu(menu, menu_items)
menu.show_menu()
```

If you want it set up differently - maybe just a call on the menu object e.g. `menu.build(menu_items)`, let me know